### PR TITLE
Deploy Digital Ocean

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,5 +12,6 @@ RUN go mod download
 COPY . .
 
 WORKDIR /app/cmd 
+RUN go build -o main main.go
 
-CMD ["go", "run", "main.go"]
+CMD ["./main"]

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -10,16 +10,16 @@ import (
 	"specialstandard/internal/service"
 	"syscall"
 
-	"github.com/joho/godotenv"
 	"github.com/sethvargo/go-envconfig"
 )
 
 func main() {
-	err := godotenv.Load("../.env")
-	if err != nil {
-		log.Fatalf("Error loading .env file: %v", err)
-		return
-	}
+	// TODO: Write logic to differentiate deployment env configuration loading vs production
+	// err := godotenv.Load("../.env")
+	// if err != nil {
+	// 	log.Fatalf("Error loading .env file: %v", err)
+	// 	return
+	// }
 
 	var config config.Config
 	if err := envconfig.Process(context.Background(), &config); err != nil {


### PR DESCRIPTION
# Description
The docker run command "go run main.go" will compile the code and then run it, however this will not work on deployment during digital ocean because compiling the code at the run/deploy stage will time out digital ocean's health check. Thus Zach and I have amended the Dockerfile to compile at the build stage and just run the executable at the deploy stage.


# How Has This Been Tested?
Battle tested

Please describe the tests that you manually ran to verify your changes (beyond any unit/integration tests written and ran).
No tests type shi

