### PR TITLE
Session filtering

### DIFF
--- a/backend/api/openapi.yaml
+++ b/backend/api/openapi.yaml
@@ -44,9 +44,10 @@ paths:
                 $ref: "#/components/schemas/Error"
 
   /sessions:
+    /sessions:
     get:
       summary: Get all sessions
-      description: Retrieve all therapy sessions from the database
+      description: Retrieve all therapy sessions from the database with optional filtering
       tags: [Sessions]
       parameters:
         - name: page
@@ -61,15 +62,65 @@ paths:
           schema:
             type: integer
             minimum: 1
+        - name: startdate
+          in: query
+          description: Filter sessions starting on or after this datetime
+          schema:
+            type: string
+            format: date-time
+          example: "2025-01-01T00:00:00Z"
+        - name: enddate
+          in: query
+          description: Filter sessions starting on or before this datetime
+          schema:
+            type: string
+            format: date-time
+          example: "2025-12-31T23:59:59Z"
+        - name: month
+          in: query
+          description: Filter sessions by month (1-12)
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 12
+          example: 9
+        - name: year
+          in: query
+          description: Filter sessions by year
+          schema:
+            type: integer
+            minimum: 1776
+            maximum: 2200
+          example: 2025
+        - name: id
+          in: query
+          description: Filter sessions that contain ALL specified student IDs (can be repeated for multiple students)
+          schema:
+            type: array
+            items:
+              type: string
+              format: uuid
+          style: form
+          explode: true
+          example: ["550e8400-e29b-41d4-a716-446655440000"]
       responses:
         "200":
-          description: List of therapy sessions
+          description: List of therapy sessions matching the filters
           content:
             application/json:
               schema:
                 type: array
                 items:
                   $ref: "#/components/schemas/Session"
+        "400":
+          description: Bad request (e.g., invalid query parameters)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                code: 400
+                message: "Invalid student ID format"
         "500":
           description: Internal server error
           content:

--- a/backend/internal/models/session.go
+++ b/backend/internal/models/session.go
@@ -33,7 +33,16 @@ type PatchSessionInput struct {
 type GetSessionRequest struct {
 	StartTime   *time.Time `query:"startdate" validate:"omitempty"`
 	EndTime     *time.Time `query:"enddate" validate:"omitempty"`
-	Month 		*int	   `query:"month" validate:"omitempty, gte=1, lte=12"`
-	Year 		*int       `query:"year" validate:"omitempty, gte=1776, lte=2200"`
-	StudentIDs 	*[]uuid.UUID `query:"id" validate:"omitempty"`
+	Month 		*int	   `query:"month" validate:"omitempty,gte=1,lte=12"`
+	Year 		*int       `query:"year" validate:"omitempty,gte=1776,lte=2200"`
+	StudentIDs 	*[]string `query:"id" validate:"omitempty"`
+}
+
+// This is what repository uses
+type GetSessionRepositoryRequest struct {
+	StartTime   *time.Time   `validate:"omitempty"`
+	EndTime     *time.Time   `validate:"omitempty"`
+	Month       *int         `validate:"omitempty,gte=1,lte=12"`
+	Year        *int         `validate:"omitempty,gte=1776,lte=2200"`
+	StudentIDs  *[]uuid.UUID `validate:"omitempty"`
 }

--- a/backend/internal/models/session.go
+++ b/backend/internal/models/session.go
@@ -31,7 +31,9 @@ type PatchSessionInput struct {
 }
 
 type GetSessionRequest struct {
-	StartTime   *time.Time `query:"start_datetime"`
-	EndTime     *time.Time `query:"end_datetime"`
-	StudentIDs 	*[]uuid.UUID `query:"ids"`
+	StartTime   *time.Time `query:"startdate" validate:"omitempty"`
+	EndTime     *time.Time `query:"enddate" validate:"omitempty"`
+	Month 		*int	   `query:"month" validate:"omitempty, gte=1, lte=12"`
+	Year 		*int       `query:"year" validate:"omitempty, gte=1776, lte=2200"`
+	StudentIDs 	*[]uuid.UUID `query:"id" validate:"omitempty"`
 }

--- a/backend/internal/models/session.go
+++ b/backend/internal/models/session.go
@@ -29,3 +29,9 @@ type PatchSessionInput struct {
 	TherapistID *uuid.UUID `json:"therapist_id"`
 	Notes       *string    `json:"notes"`
 }
+
+type GetSessionRequest struct {
+	StartTime   *time.Time `query:"start_datetime"`
+	EndTime     *time.Time `query:"end_datetime"`
+	StudentIDs 	*[]uuid.UUID `query:"ids"`
+}

--- a/backend/internal/service/handler/session/get_session.go
+++ b/backend/internal/service/handler/session/get_session.go
@@ -15,6 +15,18 @@ func (h *Handler) GetSessions(c *fiber.Ctx) error {
 		return errs.BadRequest("Invalid Pagination Query Parameters")
 	}
 
+	var req models.GetSessionRequest
+	if err := c.QueryParser(&req); err != nil {
+		return errs.BadRequest("Error parsing request body.")
+	}
+
+	// check for no students in request body
+	if len(req.StudentIDs) == 0 {
+		return errs.BadRequest("No Student ID's recieved.")
+	}
+
+
+
 	if validationErrors := xvalidator.Validator.Validate(pagination); len(validationErrors) > 0 {
 		return errs.InvalidRequestData(xvalidator.ConvertToMessages(validationErrors))
 	}
@@ -27,4 +39,16 @@ func (h *Handler) GetSessions(c *fiber.Ctx) error {
 	}
 
 	return c.Status(fiber.StatusOK).JSON(sessions)
+}
+
+// Basic function to check for duplicates in a list of uuids!
+func checkForDuplicates(ids []uuid.UUID) bool {
+	seen := make(map[uuid.UUID]bool)
+	for _, i := range ids {
+		if seen[i] {
+			return true
+		}
+		seen[i] = true
+	}
+	return false
 }

--- a/backend/internal/storage/postgres/schema/sessions.go
+++ b/backend/internal/storage/postgres/schema/sessions.go
@@ -2,8 +2,10 @@ package schema
 
 import (
 	"context"
+	"fmt"
 	"specialstandard/internal/models"
 	"specialstandard/internal/utils"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -14,13 +16,67 @@ type SessionRepository struct {
 	db *pgxpool.Pool
 }
 
-func (r *SessionRepository) GetSessions(ctx context.Context, pagination utils.Pagination) ([]models.Session, error) {
+func (r *SessionRepository) GetSessions(ctx context.Context, pagination utils.Pagination, filter *models.GetSessionRequest) ([]models.Session, error) {
 	query := `
 	SELECT id, start_datetime, end_datetime, therapist_id, notes, created_at, updated_at
-	FROM session
-	LIMIT $1 OFFSET $2`
+	FROM session`
 
-	rows, err := r.db.Query(ctx, query, pagination.Limit, pagination.GettOffset())
+	conditions := []string{}
+	args := []interface{}{}
+	argCount := 1
+
+	if filter != nil {
+		if filter.Month != nil && filter.Year != nil {
+			conditions = append(conditions, fmt.Sprintf("EXTRACT(MONTH FROM start_datetime) = $%d AND EXTRACT(YEAR FROM start_datetime) = $%d", argCount, argCount+1))
+			args = append(args, *filter.Month, *filter.Year)
+			argCount += 2
+		} else if filter.Year != nil {
+			conditions = append(conditions, fmt.Sprintf("EXTRACT(YEAR FROM start_datetime) = $%d", argCount))
+			args = append(args, *filter.Year)
+			argCount++
+		} else if filter.Month != nil {
+			conditions = append(conditions, fmt.Sprintf("EXTRACT(MONTH FROM start_datetime) = $%d", argCount))
+			args = append(args, *filter.Month)
+			argCount++
+		}
+
+		if filter.StartTime != nil {
+			conditions = append(conditions, fmt.Sprintf("start_datetime = $%d", argCount))
+			args = append(args, *filter.StartTime)
+			argCount++
+		}
+
+		if filter.EndTime != nil {
+			conditions = append(conditions, fmt.Sprintf("end_datetime = $%d", argCount))
+			args = append(args, *filter.EndTime)
+			argCount++
+		}
+
+		if filter.StudentIDs != nil && len(*filter.StudentIDs) > 0 {
+			placeholders := make([]string, len(*filter.StudentIDs))
+			for i, studentID := range *filter.StudentIDs {
+				placeholders[i] = fmt.Sprintf("$%d", argCount)
+				args = append(args, studentID)
+				argCount++
+			}
+			
+			conditions = append(conditions, fmt.Sprintf(
+				"EXISTS (SELECT 1 FROM session_student WHERE session_id = session.id AND student_id IN (%s))",
+				strings.Join(placeholders, ", "),
+			))
+		}
+	}
+
+	if(len(conditions) > 0) {
+		query += " WHERE " + strings.Join(conditions, " AND ")
+	}
+
+	query += fmt.Sprintf(`ORDER BY year DESC, month DESC LIMIT $%d OFFSET $%d`, argCount, argCount+1)
+
+	args = append(args, pagination.Limit, pagination.GettOffset())
+
+
+	rows, err := r.db.Query(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/storage/storage.go
+++ b/backend/internal/storage/storage.go
@@ -12,7 +12,7 @@ import (
 )
 
 type SessionRepository interface {
-	GetSessions(ctx context.Context, pagination utils.Pagination, filter *models.GetSessionRequest) ([]models.Session, error)
+	GetSessions(ctx context.Context, pagination utils.Pagination, filter *models.GetSessionRepositoryRequest) ([]models.Session, error)
 	GetSessionByID(ctx context.Context, id string) (*models.Session, error)
 	DeleteSession(ctx context.Context, id uuid.UUID) error
 	PostSession(ctx context.Context, session *models.PostSessionInput) (*models.Session, error)

--- a/backend/internal/storage/storage.go
+++ b/backend/internal/storage/storage.go
@@ -12,7 +12,7 @@ import (
 )
 
 type SessionRepository interface {
-	GetSessions(ctx context.Context, pagination utils.Pagination) ([]models.Session, error)
+	GetSessions(ctx context.Context, pagination utils.Pagination, filter *models.GetSessionRequest) ([]models.Session, error)
 	GetSessionByID(ctx context.Context, id string) (*models.Session, error)
 	DeleteSession(ctx context.Context, id uuid.UUID) error
 	PostSession(ctx context.Context, session *models.PostSessionInput) (*models.Session, error)


### PR DESCRIPTION
# Description

[Link to Ticket](https://github.com/GenerateNU/specialstandard/issues/31)

Please include a summary of the changes and the related issue. Please also
include relevant motivation, context, and images!

This ticket essentially adds query paramaters to the get all sessions endpoint such that a user can filter for a variety of things when using it.

- If the user doesnt want to use any query params at all, no worries, everything still works as normal!
- If the user wants to filter by a specific month
- If the user wants to filter by a specific year
- If the user wants to filter by a more specific range of start time and end time
- If the user wants to find all sessions that have the given students within them (using AND behavior (thanks ally (this is meta)))
*NOTE: All of these query paramaters can be mixed and matched (add sunglasses emoji)*

# How Has This Been Tested?
**This code has been manually tested rigorously, but not with integration tests or unit tests in fear i have a misunderstanding and will have to redo them.**

Please describe the tests that you manually ran to verify your changes (beyond any unit/integration tests written and ran).
Attached are images that display the different behavior of the filtering:
<img width="1918" height="1082" alt="ALL PARAMS WORKINGGGG" src="https://github.com/user-attachments/assets/1859faaf-3c71-4500-b275-a7202e783abc" />

<img width="1918" height="1087" alt="empty time range" src="https://github.com/user-attachments/assets/4ffc240f-b0f9-449c-ab47-63205fe13d32" />

<img width="1918" height="1085" alt="invalid time range" src="https://github.com/user-attachments/assets/f6981991-48fb-43c8-b773-086d4feccb03" />

<img width="1918" height="1081" alt="valid range" src="https://github.com/user-attachments/assets/a481735b-3f20-4c17-9b31-5efd7edc976c" />

<img width="1918" height="1088" alt="logical and for searching three ids not same session" src="https://github.com/user-attachments/assets/db7183b2-9fd6-41e7-8b06-45a6cd479cc1" />

ACCIDENTALLY CROPPED OUT URL HERE BUT THIS IS WHEN SEARCHING FOR TWO VALID IDS
<img width="1918" height="988" alt="logical and for searching for two ids" src="https://github.com/user-attachments/assets/1f5f8540-d43c-4827-81bb-7b2b8ca89cf0" />

<img width="1918" height="1078" alt="search by single id" src="https://github.com/user-attachments/assets/af1498a6-edc4-4628-92ec-565846fe93b4" />


# Checklist

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have written unit tests for my code and tested it manually
- [ ] New and existing unit tests pass locally with my changes
- [X] I have updated the OpenAPI spec, if needed
