### PR TITLE
[BE] Add Theme Info to GET Resource Endpoints

### DIFF
--- a/backend/api/openapi.yaml
+++ b/backend/api/openapi.yaml
@@ -2307,22 +2307,22 @@ components:
     ThemeInfo:
       type: object
       required:
-        - name
+        - theme_name
         - month
         - year
       properties:
-        name:
+        theme_name:
           type: string
           description: Name of the theme
           example: "Jungle Adventure"
-        month:
+        theme_month:
           type: integer
           description: Month of the theme (1-12)
           example: 6
-        year:
+        theme_year:
           type: integer
           description: Year of the theme
-          example:
+          example: 2024
         created_at:
           type: string
           format: date-time
@@ -2405,7 +2405,7 @@ components:
           type: string
           nullable: true
           description: Title of the resource (optional)
-          example: "Coping with Anxiety"
+          example: "Reading Exercises: b vs d"
         category:
           type: string
           nullable: true

--- a/backend/api/openapi.yaml
+++ b/backend/api/openapi.yaml
@@ -49,7 +49,7 @@ paths:
     post:
       summary: SignUp Feature
       description: Signs Up New User to the Platform as a Therapist
-      tags: [ Auth ]
+      tags: [Auth]
       requestBody:
         required: true
         content:
@@ -120,7 +120,7 @@ paths:
     post:
       summary: Login Feature
       description: Log into the Platform
-      tags: [ Auth ]
+      tags: [Auth]
       requestBody:
         required: true
         content:
@@ -654,14 +654,14 @@ paths:
             type: string
             example: "John"
       responses:
-        '200':
+        "200":
           description: Successful response with list of students
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Student'
+                  $ref: "#/components/schemas/Student"
               examples:
                 allStudents:
                   summary: All students (no filters)
@@ -686,12 +686,12 @@ paths:
                 emptyResults:
                   summary: No matching results
                   value: []
-        '400':
+        "400":
           description: Bad request - Invalid query parameters
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
               examples:
                 invalidTherapistId:
                   summary: Invalid therapist_id format
@@ -706,12 +706,12 @@ paths:
                     message:
                       page: "Page must be greater than or equal to 1"
                       limit: "Limit must be greater than or equal to 1"
-        '500':
+        "500":
           description: Internal server error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
     post:
       summary: Create a new student
       description: Create a new student record
@@ -1404,6 +1404,36 @@ paths:
             type: string
           required: false
           description: Filter resources by content/URL
+        - in: query
+          name: theme_name
+          schema:
+            type: string
+          required: false
+          description: Filter resources by theme name
+        - in: query
+          name: theme_month
+          schema:
+            type: integer
+          required: false
+          description: Filter resources by theme month
+        - in: query
+          name: theme_year
+          schema:
+            type: integer
+          required: false
+          description: Filter resources by theme year
+        - name: page
+          in: query
+          description: Page Number of pagination
+          schema:
+            type: integer
+            minimum: 1
+        - name: limit
+          in: query
+          description: Number of Items per page in pagination
+          schema:
+            type: integer
+            minimum: 1
       responses:
         "200":
           description: List of resources
@@ -2274,6 +2304,36 @@ components:
           description: Year of the theme
           example: 2024
 
+    ThemeInfo:
+      type: object
+      required:
+        - name
+        - month
+        - year
+      properties:
+        name:
+          type: string
+          description: Name of the theme
+          example: "Jungle Adventure"
+        month:
+          type: integer
+          description: Month of the theme (1-12)
+          example: 6
+        year:
+          type: integer
+          description: Year of the theme
+          example:
+        created_at:
+          type: string
+          format: date-time
+          description: When the theme was created
+          example: "2024-01-15T10:30:00Z"
+        updated_at:
+          type: string
+          format: date-time
+          description: When the theme was last updated
+          example: "2024-01-15T10:35:00Z"
+
     CreateResourceBody:
       type: object
       required:
@@ -2355,6 +2415,9 @@ components:
           nullable: true
           description: Content/URL of the resource (optional)
           example: "https://example.com/resource"
+        theme:
+          $ref: "#/components/schemas/ThemeInfo"
+          description: The theme associated with the resource
 
     UpdateResourceBody:
       type: object

--- a/backend/internal/models/resource.go
+++ b/backend/internal/models/resource.go
@@ -19,6 +19,11 @@ type Resource struct {
 	UpdatedAt  *time.Time `json:"updated_at"`
 }
 
+type ResourceWithTheme struct {
+	Resource
+	Theme ThemeInfo `json:"theme"`
+}
+
 type ResourceBody struct {
 	ThemeID    uuid.UUID  `json:"theme_id"`
 	GradeLevel *string    `json:"grade_level"`

--- a/backend/internal/models/theme.go
+++ b/backend/internal/models/theme.go
@@ -27,6 +27,14 @@ type UpdateThemeInput struct {
 	Year  *int    `json:"year,omitempty" validate:"omitempty,gte=1900,lte=2100"`
 }
 
+type ThemeInfo struct {
+	Name      string     `json:"theme_name" db:"theme_name"`
+	Month     int        `json:"theme_month" db:"month"`
+	Year      int        `json:"theme_year" db:"year"`
+	CreatedAt *time.Time `json:"created_at" db:"created_at"`
+	UpdatedAt *time.Time `json:"updated_at" db:"updated_at"`
+}
+
 type ThemeFilter struct {
 	Month  *int    `query:"month" validate:"omitempty,gte=1,lte=12"`
 	Year   *int    `query:"year" validate:"omitempty,gte=1900,lte=2100"`

--- a/backend/internal/service/handler/resource/get_resource.go
+++ b/backend/internal/service/handler/resource/get_resource.go
@@ -40,17 +40,23 @@ func (h *Handler) GetResources(c *fiber.Ctx) error {
 	themeMonthStr := c.Query("theme_month")
 	themeYearStr := c.Query("theme_year")
 
-	var themeMonth, themeYear int
+	var themeMonth, themeYear *int
 	if themeMonthStr != "" {
 		parsedMonth, err := strconv.Atoi(themeMonthStr)
 		if err == nil {
-			themeMonth = parsedMonth
+			if parsedMonth < 1 || parsedMonth > 12 {
+				return errs.InvalidRequestData(map[string]string{"theme_month": "month must be between 1 and 12"})
+			}
+			themeMonth = &parsedMonth
 		}
 	}
 	if themeYearStr != "" {
 		parsedYear, err := strconv.Atoi(themeYearStr)
 		if err == nil {
-			themeYear = parsedYear
+			if parsedYear < 1900 || parsedYear > 3000 {
+				return errs.InvalidRequestData(map[string]string{"theme_year": "year is invalid"})
+			}
+			themeYear = &parsedYear
 		}
 	}
 

--- a/backend/internal/service/handler/resource/get_resource.go
+++ b/backend/internal/service/handler/resource/get_resource.go
@@ -12,47 +12,6 @@ import (
 	"github.com/google/uuid"
 )
 
-// func (h *Handler) GetResources(c *fiber.Ctx) error {
-// 	themeIdStr := c.Query("theme_id")
-// 	var themeId uuid.UUID
-// 	if themeIdStr != "" {
-// 		parsedThemeId, err := uuid.Parse(themeIdStr)
-// 		if err != nil {
-// 			return errs.InvalidRequestData(map[string]string{"theme_id": "invalid UUID"})
-// 		}
-// 		themeId = parsedThemeId
-// 	}
-// 	gradeLevel := c.Query("grade_level")
-// 	dateStr := c.Query("date")
-// 	var date *time.Time
-// 	if dateStr != "" {
-// 		parsedDate, err := time.Parse("2006-01-02", dateStr)
-// 		if err == nil {
-// 			date = &parsedDate
-// 		}
-// 	}
-// 	res_type := c.Query("type")
-// 	title := c.Query("title")
-// 	category := c.Query("category")
-// 	content := c.Query("content")
-
-// 	pagination := utils.NewPagination()
-// 	if err := c.QueryParser(&pagination); err != nil {
-// 		return errs.BadRequest("Invalid Pagination Query Parameters")
-// 	}
-
-// 	if validationErrors := xvalidator.Validator.Validate(pagination); len(validationErrors) > 0 {
-// 		return errs.InvalidRequestData(xvalidator.ConvertToMessages(validationErrors))
-// 	}
-
-// 	resources, err := h.resourceRepository.GetResources(c.Context(), themeId, gradeLevel, res_type, title, category, content, date, pagination)
-// 	if err != nil {
-// 		return errs.InternalServerError(err.Error())
-// 	}
-
-// 	return c.JSON(resources)
-// }
-
 func (h *Handler) GetResources(c *fiber.Ctx) error {
 	themeIdStr := c.Query("theme_id")
 	var themeId uuid.UUID

--- a/backend/internal/service/handler/resource/get_resource.go
+++ b/backend/internal/service/handler/resource/get_resource.go
@@ -4,12 +4,54 @@ import (
 	"specialstandard/internal/errs"
 	"specialstandard/internal/utils"
 	"specialstandard/internal/xvalidator"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/google/uuid"
 )
+
+// func (h *Handler) GetResources(c *fiber.Ctx) error {
+// 	themeIdStr := c.Query("theme_id")
+// 	var themeId uuid.UUID
+// 	if themeIdStr != "" {
+// 		parsedThemeId, err := uuid.Parse(themeIdStr)
+// 		if err != nil {
+// 			return errs.InvalidRequestData(map[string]string{"theme_id": "invalid UUID"})
+// 		}
+// 		themeId = parsedThemeId
+// 	}
+// 	gradeLevel := c.Query("grade_level")
+// 	dateStr := c.Query("date")
+// 	var date *time.Time
+// 	if dateStr != "" {
+// 		parsedDate, err := time.Parse("2006-01-02", dateStr)
+// 		if err == nil {
+// 			date = &parsedDate
+// 		}
+// 	}
+// 	res_type := c.Query("type")
+// 	title := c.Query("title")
+// 	category := c.Query("category")
+// 	content := c.Query("content")
+
+// 	pagination := utils.NewPagination()
+// 	if err := c.QueryParser(&pagination); err != nil {
+// 		return errs.BadRequest("Invalid Pagination Query Parameters")
+// 	}
+
+// 	if validationErrors := xvalidator.Validator.Validate(pagination); len(validationErrors) > 0 {
+// 		return errs.InvalidRequestData(xvalidator.ConvertToMessages(validationErrors))
+// 	}
+
+// 	resources, err := h.resourceRepository.GetResources(c.Context(), themeId, gradeLevel, res_type, title, category, content, date, pagination)
+// 	if err != nil {
+// 		return errs.InternalServerError(err.Error())
+// 	}
+
+// 	return c.JSON(resources)
+// }
 
 func (h *Handler) GetResources(c *fiber.Ctx) error {
 	themeIdStr := c.Query("theme_id")
@@ -34,6 +76,24 @@ func (h *Handler) GetResources(c *fiber.Ctx) error {
 	title := c.Query("title")
 	category := c.Query("category")
 	content := c.Query("content")
+	themeName := c.Query("theme_name")
+
+	themeMonthStr := c.Query("theme_month")
+	themeYearStr := c.Query("theme_year")
+
+	var themeMonth, themeYear int
+	if themeMonthStr != "" {
+		parsedMonth, err := strconv.Atoi(themeMonthStr)
+		if err == nil {
+			themeMonth = parsedMonth
+		}
+	}
+	if themeYearStr != "" {
+		parsedYear, err := strconv.Atoi(themeYearStr)
+		if err == nil {
+			themeYear = parsedYear
+		}
+	}
 
 	pagination := utils.NewPagination()
 	if err := c.QueryParser(&pagination); err != nil {
@@ -44,12 +104,12 @@ func (h *Handler) GetResources(c *fiber.Ctx) error {
 		return errs.InvalidRequestData(xvalidator.ConvertToMessages(validationErrors))
 	}
 
-	resources, err := h.resourceRepository.GetResources(c.Context(), themeId, gradeLevel, res_type, title, category, content, date, pagination)
+	resourcesWithThemes, err := h.resourceRepository.GetResources(c.Context(), themeId, gradeLevel, res_type, title, category, content, themeName, date, themeMonth, themeYear, pagination)
 	if err != nil {
 		return errs.InternalServerError(err.Error())
 	}
 
-	return c.JSON(resources)
+	return c.JSON(resourcesWithThemes)
 }
 
 func (h *Handler) GetResourceByID(c *fiber.Ctx) error {

--- a/backend/internal/service/handler/resource/handler_test.go
+++ b/backend/internal/service/handler/resource/handler_test.go
@@ -141,11 +141,12 @@ func TestHandler_GetResources(t *testing.T) {
 			name: "successful_get_resources with default pagination",
 			url:  "",
 			mockSetup: func(m *mocks.MockResourceRepository) {
-				resources := []models.Resource{
-					{ID: uuid.New(), Title: ptrString("Resource1"), Type: ptrString("doc")},
+				resources := []models.ResourceWithTheme{
+					{Resource: models.Resource{ID: uuid.New(), Title: ptrString("Resource1"), Type: ptrString("doc")},
+						Theme: models.ThemeInfo{Name: "Spring", Month: 3, Year: 2024, CreatedAt: nil, UpdatedAt: nil}},
 				}
-				// Fix: Use mock.Anything for all parameters
-				m.On("GetResources", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, utils.NewPagination()).Return(resources, nil)
+
+				m.On("GetResources", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, utils.NewPagination()).Return(resources, nil)
 			},
 			expectedStatus: fiber.StatusOK,
 		},
@@ -153,7 +154,15 @@ func TestHandler_GetResources(t *testing.T) {
 			name: "empty_resources_list",
 			url:  "",
 			mockSetup: func(m *mocks.MockResourceRepository) {
-				m.On("GetResources", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, utils.NewPagination()).Return([]models.Resource{}, nil)
+				m.On("GetResources", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, utils.NewPagination()).Return([]models.ResourceWithTheme{}, nil)
+			},
+			expectedStatus: fiber.StatusOK,
+		},
+		{
+			name: "theme_params filter",
+			url:  "?theme_name=Spring&theme_month=3&theme_year=2024",
+			mockSetup: func(m *mocks.MockResourceRepository) {
+				m.On("GetResources", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, utils.NewPagination()).Return([]models.ResourceWithTheme{}, nil)
 			},
 			expectedStatus: fiber.StatusOK,
 		},
@@ -161,7 +170,7 @@ func TestHandler_GetResources(t *testing.T) {
 			name: "repository_error",
 			url:  "",
 			mockSetup: func(m *mocks.MockResourceRepository) {
-				m.On("GetResources", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, utils.NewPagination()).Return([]models.Resource(nil), errors.New("database error"))
+				m.On("GetResources", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, utils.NewPagination()).Return([]models.ResourceWithTheme(nil), errors.New("database error"))
 			},
 			expectedStatus: fiber.StatusInternalServerError,
 		},
@@ -176,7 +185,7 @@ func TestHandler_GetResources(t *testing.T) {
 			name:           "Bad Pagination Arguments",
 			url:            "?page=abc&limit=-1",
 			mockSetup:      func(m *mocks.MockResourceRepository) {},
-			expectedStatus: fiber.StatusBadRequest, // QueryParser Fails
+			expectedStatus: fiber.StatusBadRequest,
 		},
 		{
 			name: "Pagination Parameters",
@@ -186,7 +195,7 @@ func TestHandler_GetResources(t *testing.T) {
 					Page:  2,
 					Limit: 5,
 				}
-				m.On("GetResources", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, pagination).Return([]models.Resource{}, nil)
+				m.On("GetResources", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, pagination).Return([]models.ResourceWithTheme{}, nil)
 			},
 			expectedStatus: fiber.StatusOK,
 		},
@@ -263,7 +272,6 @@ func TestHandler_DeleteResource(t *testing.T) {
 			name:       "successful_delete_resource",
 			resourceID: resourceID.String(),
 			mockSetup: func(m *mocks.MockResourceRepository) {
-				// Fix: Use mock.Anything
 				m.On("DeleteResource", mock.Anything, mock.Anything).Return(nil)
 			},
 			expectedStatus: fiber.StatusNoContent,

--- a/backend/internal/service/handler/resource/handler_test.go
+++ b/backend/internal/service/handler/resource/handler_test.go
@@ -83,10 +83,19 @@ func TestHandler_GetResource(t *testing.T) {
 			name:       "successful_get_resource",
 			resourceID: resourceID.String(),
 			mockSetup: func(m *mocks.MockResourceRepository) {
-				m.On("GetResourceByID", mock.Anything, resourceID).Return(&models.Resource{
-					ID:    resourceID,
-					Title: ptrString("Resource1"),
-					Type:  ptrString("doc"),
+				m.On("GetResourceByID", mock.Anything, resourceID).Return(&models.ResourceWithTheme{
+					Resource: models.Resource{
+						ID:    resourceID,
+						Title: ptrString("Resource1"),
+						Type:  ptrString("doc"),
+					},
+					Theme: models.ThemeInfo{
+						Name:      "Theme1",
+						Month:     6,
+						Year:      2025,
+						CreatedAt: nil,
+						UpdatedAt: nil,
+					},
 				}, nil)
 			},
 			expectedStatus: fiber.StatusOK,
@@ -96,7 +105,7 @@ func TestHandler_GetResource(t *testing.T) {
 			name:       "repository_error",
 			resourceID: resourceID.String(),
 			mockSetup: func(m *mocks.MockResourceRepository) {
-				m.On("GetResourceByID", mock.Anything, resourceID).Return(&models.Resource{}, errors.New("database error"))
+				m.On("GetResourceByID", mock.Anything, resourceID).Return(&models.ResourceWithTheme{}, errors.New("database error"))
 			},
 			expectedStatus: fiber.StatusInternalServerError,
 			wantErr:        true,
@@ -121,7 +130,7 @@ func TestHandler_GetResource(t *testing.T) {
 			if !tt.wantErr && resp.StatusCode == fiber.StatusOK {
 				body, err := io.ReadAll(resp.Body)
 				assert.NoError(t, err)
-				var res models.Resource
+				var res models.ResourceWithTheme
 				err = json.Unmarshal(body, &res)
 				assert.NoError(t, err)
 				assert.Equal(t, resourceID, res.ID)

--- a/backend/internal/service/handler/resource/handler_test.go
+++ b/backend/internal/service/handler/resource/handler_test.go
@@ -168,12 +168,18 @@ func TestHandler_GetResources(t *testing.T) {
 			expectedStatus: fiber.StatusOK,
 		},
 		{
-			name: "theme_params filter",
+			name: "theme_params_filter",
 			url:  "?theme_name=Spring&theme_month=3&theme_year=2024",
 			mockSetup: func(m *mocks.MockResourceRepository) {
 				m.On("GetResources", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, utils.NewPagination()).Return([]models.ResourceWithTheme{}, nil)
 			},
 			expectedStatus: fiber.StatusOK,
+		},
+		{
+			name:           "invalid theme year filter",
+			url:            "?theme_year=50000",
+			mockSetup:      func(m *mocks.MockResourceRepository) {},
+			expectedStatus: fiber.StatusBadRequest,
 		},
 		{
 			name: "repository_error",

--- a/backend/internal/service/handler/resource/post_resource.go
+++ b/backend/internal/service/handler/resource/post_resource.go
@@ -9,7 +9,6 @@ import (
 )
 
 func (h *Handler) PostResource(c *fiber.Ctx) error {
-
 	var resourceBody models.ResourceBody
 	if err := c.BodyParser(&resourceBody); err != nil {
 		return errs.InvalidRequestData(map[string]string{"body": "invalid body"})

--- a/backend/internal/service/server_test.go
+++ b/backend/internal/service/server_test.go
@@ -1330,7 +1330,7 @@ func TestDeleteResourceEndpoint(t *testing.T) {
 func TestGetResourceByIDEndpoint_NotFound(t *testing.T) {
 	mockResourceRepo := new(mocks.MockResourceRepository)
 	resourceID := uuid.New()
-	mockResourceRepo.On("GetResourceByID", mock.Anything, resourceID).Return((*models.Resource)(nil), errors.New("no rows in result set"))
+	mockResourceRepo.On("GetResourceByID", mock.Anything, resourceID).Return((*models.ResourceWithTheme)(nil), errors.New("no rows in result set"))
 
 	repo := &storage.Repository{
 		Resource: mockResourceRepo,

--- a/backend/internal/service/server_test.go
+++ b/backend/internal/service/server_test.go
@@ -1216,11 +1216,20 @@ func TestCreateResourceEndpoint(t *testing.T) {
 
 func TestGetResourcesEndpoint(t *testing.T) {
 	mockResourceRepo := new(mocks.MockResourceRepository)
-	mockResourceRepo.On("GetResources", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, utils.NewPagination()).Return([]models.Resource{
+	mockResourceRepo.On("GetResources", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, utils.NewPagination()).Return([]models.ResourceWithTheme{
 		{
-			ID:    uuid.New(),
-			Title: ptrString("Resource1"),
-			Type:  ptrString("doc"),
+			Resource: models.Resource{
+				ID:    uuid.New(),
+				Title: ptrString("Resource1"),
+				Type:  ptrString("doc"),
+			},
+			Theme: models.ThemeInfo{
+				Name:      "Theme1",
+				Month:     6,
+				Year:      2025,
+				CreatedAt: nil,
+				UpdatedAt: nil,
+			},
 		},
 	}, nil)
 
@@ -1242,10 +1251,19 @@ func TestGetResourcesEndpoint(t *testing.T) {
 func TestGetResourceByIDEndpoint(t *testing.T) {
 	mockResourceRepo := new(mocks.MockResourceRepository)
 	resourceID := uuid.New()
-	mockResourceRepo.On("GetResourceByID", mock.Anything, resourceID).Return(&models.Resource{
-		ID:    resourceID,
-		Title: ptrString("Resource1"),
-		Type:  ptrString("doc"),
+	mockResourceRepo.On("GetResourceByID", mock.Anything, resourceID).Return(&models.ResourceWithTheme{
+		Resource: models.Resource{
+			ID:    resourceID,
+			Title: ptrString("Resource1"),
+			Type:  ptrString("doc"),
+		},
+		Theme: models.ThemeInfo{
+			Name:      "Theme1",
+			Month:     6,
+			Year:      2025,
+			CreatedAt: nil,
+			UpdatedAt: nil,
+		},
 	}, nil)
 
 	repo := &storage.Repository{

--- a/backend/internal/storage/mocks/resource_repository.go
+++ b/backend/internal/storage/mocks/resource_repository.go
@@ -19,14 +19,14 @@ func (m *MockResourceRepository) CreateResource(ctx context.Context, body models
 	return args.Get(0).(*models.Resource), args.Error(1)
 }
 
-func (m *MockResourceRepository) GetResourceByID(ctx context.Context, id uuid.UUID) (*models.Resource, error) {
+func (m *MockResourceRepository) GetResourceByID(ctx context.Context, id uuid.UUID) (*models.ResourceWithTheme, error) {
 	args := m.Called(ctx, id)
-	return args.Get(0).(*models.Resource), args.Error(1)
+	return args.Get(0).(*models.ResourceWithTheme), args.Error(1)
 }
 
-func (m *MockResourceRepository) GetResources(ctx context.Context, theme_id uuid.UUID, gradeLevel, res_type, title, category, content string, date *time.Time, pagination utils.Pagination) ([]models.Resource, error) {
-	args := m.Called(ctx, theme_id, gradeLevel, res_type, title, category, content, date, pagination)
-	return args.Get(0).([]models.Resource), args.Error(1)
+func (m *MockResourceRepository) GetResources(ctx context.Context, themeID uuid.UUID, gradeLevel, resType, title, category, content, themeName string, date *time.Time, themeMonth, themeYear int, pagination utils.Pagination) ([]models.ResourceWithTheme, error) {
+	args := m.Called(ctx, themeID, gradeLevel, resType, title, category, content, date, themeName, themeMonth, themeYear, pagination)
+	return args.Get(0).([]models.ResourceWithTheme), args.Error(1)
 }
 
 func (m *MockResourceRepository) UpdateResource(ctx context.Context, id uuid.UUID, resource models.UpdateResourceBody) (*models.Resource, error) {

--- a/backend/internal/storage/mocks/resource_repository.go
+++ b/backend/internal/storage/mocks/resource_repository.go
@@ -24,7 +24,7 @@ func (m *MockResourceRepository) GetResourceByID(ctx context.Context, id uuid.UU
 	return args.Get(0).(*models.ResourceWithTheme), args.Error(1)
 }
 
-func (m *MockResourceRepository) GetResources(ctx context.Context, themeID uuid.UUID, gradeLevel, resType, title, category, content, themeName string, date *time.Time, themeMonth, themeYear int, pagination utils.Pagination) ([]models.ResourceWithTheme, error) {
+func (m *MockResourceRepository) GetResources(ctx context.Context, themeID uuid.UUID, gradeLevel, resType, title, category, content, themeName string, date *time.Time, themeMonth, themeYear *int, pagination utils.Pagination) ([]models.ResourceWithTheme, error) {
 	args := m.Called(ctx, themeID, gradeLevel, resType, title, category, content, date, themeName, themeMonth, themeYear, pagination)
 	return args.Get(0).([]models.ResourceWithTheme), args.Error(1)
 }

--- a/backend/internal/storage/postgres/schema/resource_test.go
+++ b/backend/internal/storage/postgres/schema/resource_test.go
@@ -44,13 +44,18 @@ func TestResourceRepository_GetResources(t *testing.T) {
     `, resourceID, themeID, "5th Grade", testDate, "worksheet", "Math Worksheet", "mathematics", "Addition problems", time.Now(), time.Now())
 	assert.NoError(t, err)
 
-	resources, err := repo.GetResources(ctx, themeID, "", "", "", "", "", nil, utils.NewPagination())
+	resources, err := repo.GetResources(ctx, themeID, "", "", "", "", "", "", nil, 0, 0, utils.NewPagination())
 
 	// Assert
 	assert.NoError(t, err)
+	print(len(resources))
 	if assert.NotEmpty(t, resources, "Expected at least 1 resource") {
 		assert.Equal(t, "Math Worksheet", *resources[0].Title)
 		assert.Equal(t, resourceID, resources[0].ID)
+		assert.Equal(t, themeID, resources[0].ThemeID)
+		assert.Equal(t, "Test Theme", resources[0].Theme.Name)
+		assert.Equal(t, 1, resources[0].Theme.Month)
+		assert.Equal(t, 2024, resources[0].Theme.Year)
 	}
 
 	// More Tests for Pagination Behaviour
@@ -62,11 +67,11 @@ func TestResourceRepository_GetResources(t *testing.T) {
 		assert.NoError(t, err)
 	}
 
-	resources, err = repo.GetResources(ctx, themeID, "", "", "", "", "", nil, utils.NewPagination())
+	resources, err = repo.GetResources(ctx, themeID, "", "", "", "", "", "", nil, 0, 0, utils.NewPagination())
 	assert.NoError(t, err)
 	assert.Len(t, resources, 10)
 
-	resources, err = repo.GetResources(ctx, themeID, "", "", "", "", "", nil, utils.Pagination{
+	resources, err = repo.GetResources(ctx, themeID, "", "", "", "", "", "", nil, 0, 0, utils.Pagination{
 		Page:  2,
 		Limit: 9,
 	})
@@ -113,6 +118,8 @@ func TestResourceRepository_GetResourceByID(t *testing.T) {
 	if resource != nil {
 		assert.Equal(t, "Science Video", *resource.Title)
 		assert.Equal(t, resourceID, resource.ID)
+		assert.Equal(t, themeID, resource.ThemeID)
+		assert.Equal(t, "Science Theme", resource.Theme.Name)
 	}
 }
 

--- a/backend/internal/storage/postgres/schema/resource_test.go
+++ b/backend/internal/storage/postgres/schema/resource_test.go
@@ -44,7 +44,7 @@ func TestResourceRepository_GetResources(t *testing.T) {
     `, resourceID, themeID, "5th Grade", testDate, "worksheet", "Math Worksheet", "mathematics", "Addition problems", time.Now(), time.Now())
 	assert.NoError(t, err)
 
-	resources, err := repo.GetResources(ctx, themeID, "", "", "", "", "", "", nil, 0, 0, utils.NewPagination())
+	resources, err := repo.GetResources(ctx, themeID, "", "", "", "", "", "", nil, nil, nil, utils.NewPagination())
 
 	// Assert
 	assert.NoError(t, err)
@@ -67,11 +67,11 @@ func TestResourceRepository_GetResources(t *testing.T) {
 		assert.NoError(t, err)
 	}
 
-	resources, err = repo.GetResources(ctx, themeID, "", "", "", "", "", "", nil, 0, 0, utils.NewPagination())
+	resources, err = repo.GetResources(ctx, themeID, "", "", "", "", "", "", nil, nil, nil, utils.NewPagination())
 	assert.NoError(t, err)
 	assert.Len(t, resources, 10)
 
-	resources, err = repo.GetResources(ctx, themeID, "", "", "", "", "", "", nil, 0, 0, utils.Pagination{
+	resources, err = repo.GetResources(ctx, themeID, "", "", "", "", "", "", nil, nil, nil, utils.Pagination{
 		Page:  2,
 		Limit: 9,
 	})

--- a/backend/internal/storage/postgres/schema/resources.go
+++ b/backend/internal/storage/postgres/schema/resources.go
@@ -26,7 +26,7 @@ func NewResourceRepository(db *pgxpool.Pool) *ResourceRepository {
 	}
 }
 
-func (r *ResourceRepository) GetResources(ctx context.Context, themeID uuid.UUID, gradeLevel, resType, title, category, content, themeName string, date *time.Time, themeMonth, themeYear int, pagination utils.Pagination) ([]models.ResourceWithTheme, error) {
+func (r *ResourceRepository) GetResources(ctx context.Context, themeID uuid.UUID, gradeLevel, resType, title, category, content, themeName string, date *time.Time, themeMonth, themeYear *int, pagination utils.Pagination) ([]models.ResourceWithTheme, error) {
 	resources := []models.ResourceWithTheme{}
 	queryString := "SELECT r.id, r.theme_id, r.grade_level, r.date, r.type, r.title, r.category, r.content, r.created_at, r.updated_at, t.theme_name, t.month, t.year, t.created_at, t.updated_at FROM resource r JOIN theme t ON r.theme_id = t.id WHERE 1=1"
 	args := []interface{}{}
@@ -72,14 +72,14 @@ func (r *ResourceRepository) GetResources(ctx context.Context, themeID uuid.UUID
 		args = append(args, "%"+themeName+"%")
 		argNum++
 	}
-	if themeMonth != 0 {
+	if themeMonth != nil {
 		queryString += fmt.Sprintf(" AND t.month = $%d", argNum)
-		args = append(args, themeMonth)
+		args = append(args, *themeMonth)
 		argNum++
 	}
-	if themeYear != 0 {
+	if themeYear != nil {
 		queryString += fmt.Sprintf(" AND t.year = $%d", argNum)
-		args = append(args, themeYear)
+		args = append(args, *themeYear)
 		argNum++
 	}
 

--- a/backend/internal/storage/postgres/schema/resources.go
+++ b/backend/internal/storage/postgres/schema/resources.go
@@ -27,7 +27,7 @@ func NewResourceRepository(db *pgxpool.Pool) *ResourceRepository {
 }
 
 func (r *ResourceRepository) GetResources(ctx context.Context, themeID uuid.UUID, gradeLevel, resType, title, category, content, themeName string, date *time.Time, themeMonth, themeYear int, pagination utils.Pagination) ([]models.ResourceWithTheme, error) {
-	var resources []models.ResourceWithTheme
+	resources := []models.ResourceWithTheme{}
 	queryString := "SELECT r.id, r.theme_id, r.grade_level, r.date, r.type, r.title, r.category, r.content, r.created_at, r.updated_at, t.theme_name, t.month, t.year, t.created_at, t.updated_at FROM resource r JOIN theme t ON r.theme_id = t.id WHERE 1=1"
 	args := []interface{}{}
 	argNum := 1

--- a/backend/internal/storage/postgres/schema/resources.go
+++ b/backend/internal/storage/postgres/schema/resources.go
@@ -26,15 +26,15 @@ func NewResourceRepository(db *pgxpool.Pool) *ResourceRepository {
 	}
 }
 
-func (r *ResourceRepository) GetResources(ctx context.Context, theme_id uuid.UUID, gradeLevel, res_type, title, category, content string, date *time.Time, pagination utils.Pagination) ([]models.Resource, error) {
-	var resources []models.Resource
-	queryString := "SELECT id, theme_id, grade_level, date, type, title, category, content, created_at, updated_at FROM resource WHERE 1=1"
+func (r *ResourceRepository) GetResources(ctx context.Context, themeID uuid.UUID, gradeLevel, resType, title, category, content, themeName string, date *time.Time, themeMonth, themeYear int, pagination utils.Pagination) ([]models.ResourceWithTheme, error) {
+	var resources []models.ResourceWithTheme
+	queryString := "SELECT r.id, r.theme_id, r.grade_level, r.date, r.type, r.title, r.category, r.content, r.created_at, r.updated_at, t.theme_name, t.month, t.year, t.created_at, t.updated_at FROM resource r JOIN theme t ON r.theme_id = t.id WHERE 1=1"
 	args := []interface{}{}
 	argNum := 1
 
-	if theme_id != uuid.Nil {
+	if themeID != uuid.Nil {
 		queryString += fmt.Sprintf(" AND theme_id = $%d::uuid", argNum)
-		args = append(args, theme_id)
+		args = append(args, themeID)
 		argNum++
 	}
 	if gradeLevel != "" {
@@ -42,9 +42,9 @@ func (r *ResourceRepository) GetResources(ctx context.Context, theme_id uuid.UUI
 		args = append(args, gradeLevel)
 		argNum++
 	}
-	if res_type != "" {
+	if resType != "" {
 		queryString += fmt.Sprintf(" AND type = $%d", argNum)
-		args = append(args, res_type)
+		args = append(args, resType)
 		argNum++
 	}
 	if title != "" {
@@ -67,6 +67,21 @@ func (r *ResourceRepository) GetResources(ctx context.Context, theme_id uuid.UUI
 		args = append(args, date)
 		argNum++
 	}
+	if themeName != "" {
+		queryString += fmt.Sprintf(" AND t.theme_name ILIKE $%d", argNum)
+		args = append(args, "%"+themeName+"%")
+		argNum++
+	}
+	if themeMonth != 0 {
+		queryString += fmt.Sprintf(" AND t.month = $%d", argNum)
+		args = append(args, themeMonth)
+		argNum++
+	}
+	if themeYear != 0 {
+		queryString += fmt.Sprintf(" AND t.year = $%d", argNum)
+		args = append(args, themeYear)
+		argNum++
+	}
 
 	queryString += fmt.Sprintf(" LIMIT $%d OFFSET $%d", argNum, argNum+1)
 	args = append(args, pagination.Limit, pagination.GettOffset())
@@ -79,7 +94,7 @@ func (r *ResourceRepository) GetResources(ctx context.Context, theme_id uuid.UUI
 	defer rows.Close()
 
 	for rows.Next() {
-		var resource models.Resource
+		var resource models.ResourceWithTheme
 		err := rows.Scan(
 			&resource.ID,
 			&resource.ThemeID,
@@ -91,6 +106,11 @@ func (r *ResourceRepository) GetResources(ctx context.Context, theme_id uuid.UUI
 			&resource.Content,
 			&resource.CreatedAt,
 			&resource.UpdatedAt,
+			&resource.Theme.Name,
+			&resource.Theme.Month,
+			&resource.Theme.Year,
+			&resource.Theme.CreatedAt,
+			&resource.Theme.UpdatedAt,
 		)
 		if err != nil {
 			return nil, err
@@ -103,9 +123,9 @@ func (r *ResourceRepository) GetResources(ctx context.Context, theme_id uuid.UUI
 	return resources, nil
 }
 
-func (r *ResourceRepository) GetResourceByID(ctx context.Context, id uuid.UUID) (*models.Resource, error) {
-	var resource models.Resource
-	err := r.db.QueryRow(ctx, "SELECT id, theme_id, grade_level, date, type, title, category, content, created_at, updated_at FROM resource WHERE id = $1", id.String()).Scan(
+func (r *ResourceRepository) GetResourceByID(ctx context.Context, id uuid.UUID) (*models.ResourceWithTheme, error) {
+	var resource models.ResourceWithTheme
+	err := r.db.QueryRow(ctx, "SELECT r.id, r.theme_id, r.grade_level, r.date, r.type, r.title, r.category, r.content, r.created_at, r.updated_at, t.theme_name, t.month, t.year, t.created_at, t.updated_at FROM resource r JOIN theme t ON r.theme_id = t.id WHERE r.id = $1", id.String()).Scan(
 		&resource.ID,
 		&resource.ThemeID,
 		&resource.GradeLevel,
@@ -116,6 +136,11 @@ func (r *ResourceRepository) GetResourceByID(ctx context.Context, id uuid.UUID) 
 		&resource.Content,
 		&resource.CreatedAt,
 		&resource.UpdatedAt,
+		&resource.Theme.Name,
+		&resource.Theme.Month,
+		&resource.Theme.Year,
+		&resource.Theme.CreatedAt,
+		&resource.Theme.UpdatedAt,
 	)
 	if err != nil {
 		if err == pgx.ErrNoRows {

--- a/backend/internal/storage/storage.go
+++ b/backend/internal/storage/storage.go
@@ -52,8 +52,8 @@ type TherapistRepository interface {
 }
 
 type ResourceRepository interface {
-	GetResources(ctx context.Context, theme_id uuid.UUID, gradeLevel, res_type, title, category, content string, date *time.Time, pagination utils.Pagination) ([]models.Resource, error)
-	GetResourceByID(ctx context.Context, id uuid.UUID) (*models.Resource, error)
+	GetResources(ctx context.Context, themeID uuid.UUID, gradeLevel, resType, title, category, content, themeName string, date *time.Time, themeMonth, themeYear int, pagination utils.Pagination) ([]models.ResourceWithTheme, error)
+	GetResourceByID(ctx context.Context, id uuid.UUID) (*models.ResourceWithTheme, error)
 	UpdateResource(ctx context.Context, id uuid.UUID, resourceBody models.UpdateResourceBody) (*models.Resource, error)
 	CreateResource(ctx context.Context, resourceBody models.ResourceBody) (*models.Resource, error)
 	DeleteResource(ctx context.Context, id uuid.UUID) error

--- a/backend/internal/storage/storage.go
+++ b/backend/internal/storage/storage.go
@@ -52,7 +52,7 @@ type TherapistRepository interface {
 }
 
 type ResourceRepository interface {
-	GetResources(ctx context.Context, themeID uuid.UUID, gradeLevel, resType, title, category, content, themeName string, date *time.Time, themeMonth, themeYear int, pagination utils.Pagination) ([]models.ResourceWithTheme, error)
+	GetResources(ctx context.Context, themeID uuid.UUID, gradeLevel, resType, title, category, content, themeName string, date *time.Time, themeMonth, themeYear *int, pagination utils.Pagination) ([]models.ResourceWithTheme, error)
 	GetResourceByID(ctx context.Context, id uuid.UUID) (*models.ResourceWithTheme, error)
 	UpdateResource(ctx context.Context, id uuid.UUID, resourceBody models.UpdateResourceBody) (*models.Resource, error)
 	CreateResource(ctx context.Context, resourceBody models.ResourceBody) (*models.Resource, error)


### PR DESCRIPTION
# Description

[Link to Ticket](https://github.com/GenerateNU/specialstandard/issues/26)

Resources are pretty tied to Theme. This edit includes a theme json in every GET resource returned object, returning all fields except the redundant ID field. A JSON was incorporated to add better separation between the two items. This could be amended.

# How Has This Been Tested?

GET /resources (there's more elements in the list response I promise)
<img width="865" height="541" alt="image" src="https://github.com/user-attachments/assets/f42bc50a-699f-4913-b176-6b9ac74fb97d" />

GET /resources/{id}
<img width="1708" height="766" alt="image" src="https://github.com/user-attachments/assets/7cb148d5-4c84-4a68-8854-7045825acd6b" />

GET /resources?theme_name=Nature
<img width="1162" height="864" alt="image" src="https://github.com/user-attachments/assets/dd91e3d0-3917-46c7-95e0-4f3b0cce5a19" />

FIX: /resources?grade_level=invalid param
returns [] now instead of null
<img width="1723" height="588" alt="image" src="https://github.com/user-attachments/assets/717c83a5-79c5-4d1c-b1ea-6ab0f72439a1" />

GET /resources?theme_name=invalid
<img width="1719" height="566" alt="image" src="https://github.com/user-attachments/assets/d082b133-7c1b-46de-89b5-24dfef925c40" />

Edited existing tests to assert the existence of theme fields, added a couple new cases.

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have written unit tests for my code and tested it manually
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the OpenAPI spec, if needed

closes #26 