### PR TITLE
Change session page so that editing is all at once

### DIFF
--- a/backend/internal/storage/postgres/storage.go
+++ b/backend/internal/storage/postgres/storage.go
@@ -25,9 +25,6 @@ func ConnectDatabase(ctx context.Context, config config.DB) (*pgxpool.Pool, erro
 	// This prevents "prepared statement already exists" errors when connections are reused
 	dbConfig.ConnConfig.DefaultQueryExecMode = pgx.QueryExecModeSimpleProtocol
 
-	// Disable prepared statement caching to avoid conflicts with connection pooling
-	dbConfig.ConnConfig.DefaultQueryExecMode = pgx.QueryExecModeSimpleProtocol
-
 	conn, err := pgxpool.NewWithConfig(ctx, dbConfig)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# Description

This changes the editing mode to just one edit button at the top, instead of one for metadata and one for students.
<img width="1727" height="961" alt="Screenshot 2025-11-03 at 7 14 12 PM" src="https://github.com/user-attachments/assets/eb9eb736-b8e7-425f-9d58-2b41f256024f" />
<img width="1728" height="992" alt="Screenshot 2025-11-03 at 7 14 23 PM" src="https://github.com/user-attachments/assets/a743b89b-333d-4085-b04e-028f82c3a6b3" />

# How Has This Been Tested?

Please describe the tests that you manually ran to verify your changes (beyond any unit/integration tests written and ran).

# Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have written unit tests for my code and tested it manually
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the OpenAPI spec, if needed
