### PR TITLE
fix: clear local storage recently viewed students on logout

### DIFF
--- a/frontend/src/contexts/authContext.tsx
+++ b/frontend/src/contexts/authContext.tsx
@@ -54,7 +54,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       }
       else {
         setUserId(null)
-        localStorage.removeItem('recentlyViewedStudents')     
       }
       setIsLoading(false)
     }

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -32,6 +32,7 @@ export function useAuth() {
             // Clear localStorage
             localStorage.removeItem('jwt')
             localStorage.removeItem('userId')
+            localStorage.removeItem('recentlyViewedStudents')     
             // Clear cookies
             document.cookie.split(';').forEach((cookie) => {
                 const eqPos = cookie.indexOf('=')
@@ -65,6 +66,7 @@ export function useAuth() {
             // Clear auth data after successful password reset
             localStorage.removeItem('jwt')
             localStorage.removeItem('userId')
+            localStorage.removeItem('recentlyViewedStudents')     
             queryClient.setQueryData(['user'], null)
             queryClient.invalidateQueries({ queryKey: ['user'] })
         },
@@ -75,6 +77,8 @@ export function useAuth() {
         onSuccess: () => {
             localStorage.removeItem('jwt')
             localStorage.removeItem('userId')
+            localStorage.removeItem('recentlyViewedStudents')     
+
             queryClient.setQueryData(['user'], null)
             queryClient.invalidateQueries({ queryKey: ['user'] })
         },

--- a/frontend/src/lib/api/apiClient.ts
+++ b/frontend/src/lib/api/apiClient.ts
@@ -61,6 +61,7 @@ apiClient.interceptors.response.use(
           // Clear localStorage
           localStorage.removeItem('jwt')
           localStorage.removeItem('userId')
+          localStorage.removeItem('recentlyViewedStudents')     
 
           // Clear cookies for backwards compatibility
           document.cookie.split(';').forEach((cookie) => {


### PR DESCRIPTION
# Description

[Link to Ticket](insert the link to your ticket inside the parenthesis here)

Please include a summary of the changes and the related issue. Please also
include relevant motivation, context, and images!


Fix bug where logout doesn't clear recently viewed students

# How Has This Been Tested?

Please describe the tests that you manually ran to verify your changes (beyond any unit/integration tests written and ran).
1. Login into acc 1:
<img width="411" height="715" alt="Screenshot 2025-11-25 at 9 09 34 PM" src="https://github.com/user-attachments/assets/96779dfc-1e44-472a-b99e-d0b11327257d" />

2. Login to acc 2:
<img width="358" height="685" alt="Screenshot 2025-11-25 at 9 09 56 PM" src="https://github.com/user-attachments/assets/04d5d1c3-32d3-4eeb-930c-f38303fccb7a" />

3. Log back into acc 1
<img width="380" height="695" alt="Screenshot 2025-11-25 at 9 10 05 PM" src="https://github.com/user-attachments/assets/fd008dd3-b5f3-4ed0-90fb-756074ede1d5" />

# Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have written unit tests for my code and tested it manually
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the OpenAPI spec, if needed
