### PR TITLE
remove theme and extra level selection page

### DIFF
--- a/frontend/src/app/sessions/[id]/curriculum/page.tsx
+++ b/frontend/src/app/sessions/[id]/curriculum/page.tsx
@@ -149,7 +149,8 @@ export default function CurriculumPage({ params }: PageProps) {
                   size="lg"
                   className="h-24 text-xl bg-pink hover:bg-pink-hover text-white gap-3"
                   onClick={() => {
-                  router.push(`/games?sessionId=${id}`)
+                    setCurrentLevel(selectedLevel)
+                    router.push(`/games?sessionId=${id}`)
                   }}
                 >
                   <Dumbbell className="w-6 h-6" />

--- a/frontend/src/hooks/useThemes.ts
+++ b/frontend/src/hooks/useThemes.ts
@@ -2,10 +2,16 @@ import { useAuthContext } from '@/contexts/authContext'
 import { getThemes as getThemesApi } from '@/lib/api/themes'
 import type {
   CreateThemeInput,
+  GetThemesParams,
   Theme,
 } from '@/lib/api/theSpecialStandardAPI.schemas'
 import type { QueryObserverResult } from '@tanstack/react-query'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+
+interface UseThemesOptions {
+  month?: number // 1-12
+  year?: number
+}
 
 interface UseThemesReturn {
   themes: Theme[]
@@ -15,10 +21,14 @@ interface UseThemesReturn {
   addTheme: (theme: CreateThemeInput) => void
 }
 
-export function useThemes(): UseThemesReturn {
+export function useThemes(options?: UseThemesOptions): UseThemesReturn {
   const queryClient = useQueryClient()
   const api = getThemesApi()
   const { userId: therapistId } = useAuthContext()
+
+  const params: GetThemesParams | undefined = options?.month || options?.year 
+    ? { month: options.month, year: options.year }
+    : undefined
 
   const {
     data: themesResponse,
@@ -26,8 +36,8 @@ export function useThemes(): UseThemesReturn {
     error,
     refetch,
   } = useQuery({
-    queryKey: ['themes', therapistId],
-    queryFn: () => api.getThemes(),
+    queryKey: ['themes', therapistId, options?.month, options?.year],
+    queryFn: () => api.getThemes(params),
   })
 
   const themes = themesResponse ?? []


### PR DESCRIPTION
# Description

[Link to Ticket](https://github.com/GenerateNU/specialstandard/issues/213)
This removes the theme selection page in a session and the second level selection page.

Also updated the themes database to make the nature one everyone's game data is in December 2025.


# How Has This Been Tested?

Please describe the tests that you manually ran to verify your changes (beyond any unit/integration tests written and ran).

# Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have written unit tests for my code and tested it manually
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the OpenAPI spec, if needed
